### PR TITLE
fix: reset spec-summary upon context cancellation

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -22,6 +22,8 @@ const LastApplliedName = "last-applied-configuration-info"
 const ContextServiceDeploymentInfo = "serviceDeploymentInfo"
 const MicroServiceSuccessDeploymentResult = "success"
 
+const ContextGoCtx = "contextGoCtx"
+
 // Struct constants
 const KubernetesHelperImpl = "kubernetesHelperImpl"
 const ServicesUsersContextList = "ctxServicesUsersList"

--- a/pkg/core/commonservice_controller.go
+++ b/pkg/core/commonservice_controller.go
@@ -71,9 +71,13 @@ func (r *ReconcileCommonService) Reconcile(ctx context.Context, request reconcil
 	//we always return error == nil, this way we implement our own logic of reconcile retries
 	var executionErrResult error
 
+	var deploymentContext ExecutionContext
+
 	defer func() {
 		panicStackTrace := string(debug.Stack())
 		var errMsg string
+		var isCancellation bool
+
 		if err := recover(); err != nil {
 			// Panic
 			var stringErrorMsg string
@@ -82,7 +86,7 @@ func (r *ReconcileCommonService) Reconcile(ctx context.Context, request reconcil
 				stringErrorMsg = v
 			case error:
 				var dre *DRExecutionError
-				if errors.As(err.(error), &dre) {
+				if errors.As(v, &dre) {
 					statusErr := crHandler.SetDRStatus("failed").Commit()
 					if statusErr != nil {
 						logger.Sugar().Errorf("Failed to update DR status to 'failed', err: %v", statusErr)
@@ -90,13 +94,27 @@ func (r *ReconcileCommonService) Reconcile(ctx context.Context, request reconcil
 					logger.Error(v.Error() + "\n" + panicStackTrace)
 					return
 				}
+				if errors.Is(v, context.Canceled) || errors.Is(v, context.DeadlineExceeded) || ctx.Err() != nil {
+					isCancellation = true
+				}
 				stringErrorMsg = v.Error()
 			}
 
 			errMsg = stringErrorMsg + "\n" + panicStackTrace
 		} else if executionErrResult != nil {
 			// Usual exception
+			if errors.Is(executionErrResult, context.Canceled) || errors.Is(executionErrResult, context.DeadlineExceeded) || ctx.Err() != nil {
+				isCancellation = true
+			}
 			errMsg = executionErrResult.Error()
+		}
+
+		if isCancellation {
+			logger.Info(fmt.Sprintf("Reconciliation interrupted by shutdown/cancellation: %s. Resetting spec hash so the next reconcile retries the full flow.", errMsg))
+			if resetErr := doResetSpec(deploymentContext); resetErr != nil {
+				logger.Sugar().Errorf("Failed to reset spec config map after interrupted reconcile, err: %v", resetErr)
+			}
+			return
 		}
 
 		if errMsg != "" {
@@ -113,7 +131,7 @@ func (r *ReconcileCommonService) Reconcile(ctx context.Context, request reconcil
 	}()
 
 	r.Reconciler.SetServiceInstance(r.Client, request)
-	deploymentContext := GetExecutionContext(map[string]interface{}{
+	deploymentContext = GetExecutionContext(map[string]interface{}{
 		constants.ContextSpec:                       r.Reconciler.GetInstance(),
 		constants.ContextSchema:                     r.Scheme,
 		constants.ContextRequest:                    request,
@@ -123,6 +141,7 @@ func (r *ReconcileCommonService) Reconcile(ctx context.Context, request reconcil
 		constants.ContextConsulRegistration:         r.Reconciler.GetConsulRegistration(),
 		constants.ContextConsulServiceRegistrations: r.Reconciler.GetConsulServiceRegistrations(),
 		constants.ContextHashConfigMap:              r.Reconciler.GetConfigMapName(),
+		constants.ContextGoCtx:   ctx,
 	})
 
 	deploymentVersion := getEnv("DEPLOYMENT_VERSION", "")
@@ -245,6 +264,11 @@ func (r *ReconcileCommonService) Reconcile(ctx context.Context, request reconcil
 	}
 
 	if specHasChanges && executionErrResult == nil {
+		if ctx.Err() != nil {
+			logger.Info(fmt.Sprintf("Context error, skipping reconciliation: %v", ctx.Err()))
+			return reconcile.Result{}, nil
+		}
+
 		statusErr := crHandler.SetCRCondition(true, "In Progress", nil, "ReconcileCycleInProgress").SetDRStatus("running").Commit()
 		if statusErr != nil {
 			logger.Sugar().Errorf("Failed to update CR status, err: %v", statusErr)


### PR DESCRIPTION
CPCAP-11817
Problem Description: During rolling upgrade of Redis from LTS to the latest version, the old redis-operator pod starts reconciliation and runs the Monitoring and RobotTests compounds. It applies the Deployment templates, including secret env variables, but the container image itself comes from the CR spec, which already points to the latest image. This mismatch between the old pod's template logic and the new image causes the container hardening test to fail. Since the new redis-operator pod (running the correct, updated logic) sees the spec summary as unchanged, it skips reconciliation entirely and never gets a chance to reapply the templates correctly, leaving the hardening test failure unresolved.

Root Cause: Reconcile logic in _qubership-nosqldb-operator-core_ writes the spec-summary hash as soon as a spec change is detected, before Executor.Execute() (Adapter/Monitoring/RobotTests) has actually run. If the old pod is killed mid-Execute(), as happens during the rolling upgrade, that hash is already committed. So when the new pod (with the correct, upgraded reconcile logic) picks up this CR, it sees a matching hash and assumes there's nothing to do, even though the templates it applied were built with the old pod's stale logic against the new image. 

Solution:
1. Make the shutdown signal visible to reconcilaation logic by storing ContextGoCtx in deploymentContext.
2. WaitForPodsReady and WaitForTestsReady calls in redis are now raced against the shutdown context to unblock waiting for success or time out like before.
3. When the context is cancelled the spec summary hash (in last-applied-configuration-info configmap) would be reset by reconciliation logic.
4. redis-operator's controller now watches for delete events on this spec ConfigMap and maps them back to the owning CR, automatically queuing a fresh reconcile request.

changes in redis: https://github.com/Netcracker/qubership-redis/commit/75010644683896d221ce80fa9a9453d07e601c1c